### PR TITLE
Voting on Articles and Comments

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -300,3 +300,7 @@
   transform: scale(1.05);
   cursor: pointer;
 }
+
+.orange-highlight {
+  color: rgb(252, 47, 0);
+}

--- a/src/App.css
+++ b/src/App.css
@@ -304,3 +304,8 @@
 .orange-highlight {
   color: rgb(252, 47, 0);
 }
+
+.greyed-out {
+  color: rgb(121, 121, 121);
+  opacity: 50%;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -31,6 +31,7 @@
   text-decoration-color: rgb(252, 47, 0);
   color: rgb(252, 47, 0);
   transform: scale(1.05);
+  cursor: pointer;
 }
 
 .plus {
@@ -40,6 +41,7 @@
 
 .article-query-links:hover .plus {
   color: rgb(252, 47, 0);
+  cursor: pointer;
 }
 
 .article-card-container {
@@ -63,6 +65,7 @@
   text-underline-offset: 0.2em;
   text-decoration-thickness: 0.25em;
   transform: scale(1.05);
+  cursor: pointer;
 }
 
 .article-list-layout {
@@ -89,6 +92,7 @@
   text-decoration: underline;
   text-underline-offset: 0.2em;
   text-decoration-thickness: 0.25em;
+  cursor: pointer;
 }
 
 .article-card-body {
@@ -120,6 +124,7 @@
 .article-card-read-button1:hover {
   background-color: rgb(252, 47, 0);
   color: white;
+  cursor: pointer;
 }
 
 .clock {
@@ -142,11 +147,13 @@
 .up-arrow:hover {
   color: rgb(252, 47, 0);
   transform: scale(1.05);
+  cursor: pointer;
 }
 
 .down-arrow:hover {
   color: rgb(252, 47, 0);
   transform: scale(1.05);
+  cursor: pointer;
 }
 
 .article-card-footer {
@@ -164,6 +171,7 @@
 
 .article-comments:hover .comment-icon {
   color: rgb(252, 47, 0);
+  cursor: pointer;
 }
 
 .article-comments:hover {
@@ -173,6 +181,7 @@
   text-decoration-color: rgb(252, 47, 0);
   color: rgb(252, 47, 0);
   transform: scale(1.05);
+  cursor: pointer;
 }
 
 .article-topic-header {
@@ -252,6 +261,7 @@
   text-underline-offset: 0.2em;
   text-decoration-thickness: 0.25em;
   transform: scale(1.05);
+  cursor: pointer;
 }
 
 .comment-card-body {
@@ -282,9 +292,11 @@
 .comment-up-arrow:hover {
   color: rgb(252, 47, 0);
   transform: scale(1.05);
+  cursor: pointer;
 }
 
 .comment-down-arrow:hover {
   color: rgb(252, 47, 0);
   transform: scale(1.05);
+  cursor: pointer;
 }

--- a/src/components/Articles/ArticleCard.jsx
+++ b/src/components/Articles/ArticleCard.jsx
@@ -1,11 +1,7 @@
 import formatDate from "../../utils/date-format";
-import {
-  AccessTimeOutlined,
-  ArrowDownwardSharp,
-  ArrowUpwardSharp,
-  ModeCommentOutlined,
-} from "@mui/icons-material";
+import { AccessTimeOutlined } from "@mui/icons-material";
 import { Link } from "react-router-dom";
+import ArticleVotes from "../Votes/ArticleVotes";
 
 const ArticleCard = ({ article }) => {
   const {
@@ -44,17 +40,11 @@ const ArticleCard = ({ article }) => {
             </button>
           </Link>
         </article>
-        <div className="article-card-footer">
-          <div className="article-card-vote-count">
-            <ArrowUpwardSharp className="up-arrow" />
-            {votes}
-            <ArrowDownwardSharp className="down-arrow" />
-          </div>
-          <div className="article-comments">
-            <ModeCommentOutlined className="comment-icon" />
-            {`${comment_count} comments`}
-          </div>
-        </div>
+        <ArticleVotes
+          article_id={article_id}
+          votes={votes}
+          comment_count={comment_count}
+        />
       </div>
     </div>
   );

--- a/src/components/Articles/ArticleCard.jsx
+++ b/src/components/Articles/ArticleCard.jsx
@@ -44,6 +44,7 @@ const ArticleCard = ({ article }) => {
           article_id={article_id}
           votes={votes}
           comment_count={comment_count}
+          author={author}
         />
       </div>
     </div>

--- a/src/components/Articles/SingleArticle.jsx
+++ b/src/components/Articles/SingleArticle.jsx
@@ -1,16 +1,12 @@
 import formatDate from "../../utils/date-format";
-import {
-  AccessTimeOutlined,
-  ArrowDownwardSharp,
-  ArrowUpwardSharp,
-  ModeCommentOutlined,
-} from "@mui/icons-material";
+import { AccessTimeOutlined } from "@mui/icons-material";
 import { Link, useParams } from "react-router-dom";
 import { useContext, useEffect, useState } from "react";
 import * as api from "../../utils/api.js";
 import ErrorComponent from "../Errors/ErrorComponent";
 import { UserContext } from "../../contexts/UserContext";
 import CommentsCard from "../Comments/CommentsCard";
+import ArticleVotes from "../Votes/ArticleVotes";
 
 const SingleArticle = () => {
   const { article_id } = useParams();
@@ -78,22 +74,11 @@ const SingleArticle = () => {
             <h3 className="article-card-title">{title}</h3>
             <main className="article-card-body">{body}</main>
           </article>
-          <div className="article-card-footer">
-            <div className="article-card-vote-count">
-              <ArrowUpwardSharp className="up-arrow" />
-              {votes}
-              <ArrowDownwardSharp className="down-arrow" />
-            </div>
-            <div className="article-comments">
-              <ModeCommentOutlined className="comment-icon" />
-              {`${comment_count} comments`}
-            </div>
-            <div>
-              <button className="article-card-read-button article-card-read-button1 article-card-add-comment">
-                add comment
-              </button>
-            </div>
-          </div>
+          <ArticleVotes
+            article_id={article_id}
+            votes={votes}
+            comment_count={comment_count}
+          />
         </div>
         <main>
           {comments.map((comment) => {

--- a/src/components/Articles/SingleArticle.jsx
+++ b/src/components/Articles/SingleArticle.jsx
@@ -78,6 +78,7 @@ const SingleArticle = () => {
             article_id={article_id}
             votes={votes}
             comment_count={comment_count}
+            author={author}
           />
         </div>
         <main>

--- a/src/components/Comments/CommentsCard.jsx
+++ b/src/components/Comments/CommentsCard.jsx
@@ -1,12 +1,9 @@
-import {
-  AccessTimeOutlined,
-  ArrowDownwardSharp,
-  ArrowUpwardSharp,
-} from "@mui/icons-material";
+import { AccessTimeOutlined } from "@mui/icons-material";
 import formatDate from "../../utils/date-format";
+import CommentVotes from "../Votes/CommentVotes";
 
 const CommentsCard = ({ comment }) => {
-  const { author, body, created_at, votes } = comment;
+  const { comment_id, author, body, created_at, votes } = comment;
   return (
     <div>
       <div className="comment-card-container">
@@ -18,13 +15,7 @@ const CommentsCard = ({ comment }) => {
         <article>
           <main className="comment-card-body">{body}</main>
         </article>
-        <div className="comment-card-footer">
-          <div className="comment-card-vote-count">
-            <ArrowUpwardSharp className="comment-up-arrow" />
-            {votes}
-            <ArrowDownwardSharp className="comment-down-arrow" />
-          </div>
-        </div>
+        <CommentVotes comment_id={comment_id} votes={votes} />
       </div>
     </div>
   );

--- a/src/components/Comments/CommentsCard.jsx
+++ b/src/components/Comments/CommentsCard.jsx
@@ -15,7 +15,7 @@ const CommentsCard = ({ comment }) => {
         <article>
           <main className="comment-card-body">{body}</main>
         </article>
-        <CommentVotes comment_id={comment_id} votes={votes} />
+        <CommentVotes comment_id={comment_id} votes={votes} author={author} />
       </div>
     </div>
   );

--- a/src/components/Votes/ArticleVotes.jsx
+++ b/src/components/Votes/ArticleVotes.jsx
@@ -1,13 +1,15 @@
 import * as api from "../../utils/api.js";
-import { useState } from "react";
+import { useContext, useState } from "react";
 import {
   ArrowDownwardSharp,
   ArrowUpwardSharp,
   ModeCommentOutlined,
 } from "@mui/icons-material";
 import { IconButton } from "@mui/material";
+import { UserContext } from "../../contexts/UserContext.jsx";
 
-const ArticleVotes = ({ article_id, votes, comment_count }) => {
+const ArticleVotes = ({ article_id, votes, comment_count, author }) => {
+  const { loggedInUser } = useContext(UserContext);
   const [articleVotes, setArticleVotes] = useState(votes);
   const [voteCheck, setVoteCheck] = useState(0);
 
@@ -20,19 +22,35 @@ const ArticleVotes = ({ article_id, votes, comment_count }) => {
   return (
     <div className="article-card-footer">
       <div className="article-card-vote-count">
-        <IconButton onClick={() => voteAction(1)} disabled={voteCheck === 1}>
+        <IconButton
+          onClick={() => voteAction(1)}
+          disabled={voteCheck === 1 || loggedInUser.username === author}
+        >
           <ArrowUpwardSharp
             className={`up-arrow ${
-              voteCheck === 1 ? `orange-highlight` : null
+              voteCheck === 1
+                ? `orange-highlight`
+                : loggedInUser.username === author
+                ? `greyed-out`
+                : null
             }`}
+            disabled={loggedInUser.username === author}
           />
         </IconButton>
         {articleVotes}
-        <IconButton onClick={() => voteAction(-1)} disabled={voteCheck === -1}>
+        <IconButton
+          onClick={() => voteAction(-1)}
+          disabled={voteCheck === -1 || loggedInUser.username === author}
+        >
           <ArrowDownwardSharp
             className={`down-arrow ${
-              voteCheck === -1 ? `orange-highlight` : null
+              voteCheck === -1
+                ? `orange-highlight`
+                : loggedInUser.username === author
+                ? `greyed-out`
+                : null
             }`}
+            disabled={loggedInUser.username === author}
           />
         </IconButton>
       </div>

--- a/src/components/Votes/ArticleVotes.jsx
+++ b/src/components/Votes/ArticleVotes.jsx
@@ -1,0 +1,35 @@
+import * as api from "../../utils/api.js";
+import { useState } from "react";
+import {
+  ArrowDownwardSharp,
+  ArrowUpwardSharp,
+  ModeCommentOutlined,
+} from "@mui/icons-material";
+
+const ArticleVotes = ({ article_id, votes, comment_count }) => {
+  const [articleVotes, setArticleVotes] = useState(votes);
+
+  const voteAction = (votecrement) => {
+    setArticleVotes((currentVoteCount) => currentVoteCount + votecrement);
+    api.patchArticleVotes(article_id, votecrement);
+  };
+
+  return (
+    <div className="article-card-footer">
+      <div className="article-card-vote-count">
+        <ArrowUpwardSharp className="up-arrow" onClick={() => voteAction(1)} />
+        {articleVotes}
+        <ArrowDownwardSharp
+          className="down-arrow"
+          onClick={() => voteAction(-1)}
+        />
+      </div>
+      <div className="article-comments">
+        <ModeCommentOutlined className="comment-icon" />
+        {`${comment_count} comments`}
+      </div>
+    </div>
+  );
+};
+
+export default ArticleVotes;

--- a/src/components/Votes/ArticleVotes.jsx
+++ b/src/components/Votes/ArticleVotes.jsx
@@ -5,24 +5,36 @@ import {
   ArrowUpwardSharp,
   ModeCommentOutlined,
 } from "@mui/icons-material";
+import { IconButton } from "@mui/material";
 
 const ArticleVotes = ({ article_id, votes, comment_count }) => {
   const [articleVotes, setArticleVotes] = useState(votes);
+  const [voteCheck, setVoteCheck] = useState(0);
 
   const voteAction = (votecrement) => {
-    setArticleVotes((currentVoteCount) => currentVoteCount + votecrement);
     api.patchArticleVotes(article_id, votecrement);
+    setArticleVotes((currentVoteCount) => currentVoteCount + votecrement);
+    setVoteCheck((zero) => zero + votecrement);
   };
 
   return (
     <div className="article-card-footer">
       <div className="article-card-vote-count">
-        <ArrowUpwardSharp className="up-arrow" onClick={() => voteAction(1)} />
+        <IconButton onClick={() => voteAction(1)} disabled={voteCheck === 1}>
+          <ArrowUpwardSharp
+            className={`up-arrow ${
+              voteCheck === 1 ? `orange-highlight` : null
+            }`}
+          />
+        </IconButton>
         {articleVotes}
-        <ArrowDownwardSharp
-          className="down-arrow"
-          onClick={() => voteAction(-1)}
-        />
+        <IconButton onClick={() => voteAction(-1)} disabled={voteCheck === -1}>
+          <ArrowDownwardSharp
+            className={`down-arrow ${
+              voteCheck === -1 ? `orange-highlight` : null
+            }`}
+          />
+        </IconButton>
       </div>
       <div className="article-comments">
         <ModeCommentOutlined className="comment-icon" />

--- a/src/components/Votes/ArticleVotes.jsx
+++ b/src/components/Votes/ArticleVotes.jsx
@@ -13,8 +13,15 @@ const ArticleVotes = ({ article_id, votes, comment_count, author }) => {
   const [articleVotes, setArticleVotes] = useState(votes);
   const [voteCheck, setVoteCheck] = useState(0);
 
+  // look to make dry-er at some point instead of two files for comments / articles, make one component re-useable by both.
+
   const voteAction = (votecrement) => {
-    api.patchArticleVotes(article_id, votecrement);
+    api.patchArticleVotes(article_id, votecrement).catch((err) => {
+      setArticleVotes((currentVoteCount) => currentVoteCount - votecrement);
+      return alert(
+        "Error: vote not registered, please refresh the page and try again."
+      );
+    });
     setArticleVotes((currentVoteCount) => currentVoteCount + votecrement);
     setVoteCheck((zero) => zero + votecrement);
   };

--- a/src/components/Votes/CommentVotes.jsx
+++ b/src/components/Votes/CommentVotes.jsx
@@ -10,7 +10,12 @@ const CommentVotes = ({ comment_id, votes, author }) => {
   const [voteCheck, setVoteCheck] = useState(0);
 
   const voteAction = (votecrement) => {
-    api.patchCommentVotes(comment_id, votecrement);
+    api.patchCommentVotes(comment_id, votecrement).catch((err) => {
+      setCommentVotes((currentVoteCount) => currentVoteCount - votecrement);
+      return alert(
+        "Error: vote not registered, please refresh the page and try again."
+      );
+    });
     setCommentVotes((currentVoteCount) => currentVoteCount + votecrement);
     setVoteCheck((zero) => zero + votecrement);
   };

--- a/src/components/Votes/CommentVotes.jsx
+++ b/src/components/Votes/CommentVotes.jsx
@@ -1,0 +1,27 @@
+import * as api from "../../utils/api.js";
+import { useState } from "react";
+import { ArrowDownwardSharp, ArrowUpwardSharp } from "@mui/icons-material";
+
+const CommentVotes = ({ comment_id, votes }) => {
+  const [commentVotes, setCommentVotes] = useState(votes);
+
+  const voteAction = (votecrement) => {
+    setCommentVotes((currentVoteCount) => currentVoteCount + votecrement);
+    api.patchCommentVotes(comment_id, votecrement);
+  };
+
+  return (
+    <div className="comment-card-footer">
+      <div className="comment-card-vote-count">
+        <ArrowUpwardSharp className="up-arrow" onClick={() => voteAction(1)} />
+        {commentVotes}
+        <ArrowDownwardSharp
+          className="down-arrow"
+          onClick={() => voteAction(-1)}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default CommentVotes;

--- a/src/components/Votes/CommentVotes.jsx
+++ b/src/components/Votes/CommentVotes.jsx
@@ -1,24 +1,36 @@
 import * as api from "../../utils/api.js";
 import { useState } from "react";
 import { ArrowDownwardSharp, ArrowUpwardSharp } from "@mui/icons-material";
+import { IconButton } from "@mui/material";
 
 const CommentVotes = ({ comment_id, votes }) => {
   const [commentVotes, setCommentVotes] = useState(votes);
+  const [voteCheck, setVoteCheck] = useState(0);
 
   const voteAction = (votecrement) => {
-    setCommentVotes((currentVoteCount) => currentVoteCount + votecrement);
     api.patchCommentVotes(comment_id, votecrement);
+    setCommentVotes((currentVoteCount) => currentVoteCount + votecrement);
+    setVoteCheck((zero) => zero + votecrement);
   };
 
   return (
     <div className="comment-card-footer">
       <div className="comment-card-vote-count">
-        <ArrowUpwardSharp className="up-arrow" onClick={() => voteAction(1)} />
+        <IconButton onClick={() => voteAction(1)} disabled={voteCheck === 1}>
+          <ArrowUpwardSharp
+            className={`up-arrow ${
+              voteCheck === 1 ? `orange-highlight` : null
+            }`}
+          />
+        </IconButton>
         {commentVotes}
-        <ArrowDownwardSharp
-          className="down-arrow"
-          onClick={() => voteAction(-1)}
-        />
+        <IconButton onClick={() => voteAction(-1)} disabled={voteCheck === -1}>
+          <ArrowDownwardSharp
+            className={`down-arrow ${
+              voteCheck === -1 ? `orange-highlight` : null
+            }`}
+          />
+        </IconButton>
       </div>
     </div>
   );

--- a/src/components/Votes/CommentVotes.jsx
+++ b/src/components/Votes/CommentVotes.jsx
@@ -1,9 +1,11 @@
 import * as api from "../../utils/api.js";
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { ArrowDownwardSharp, ArrowUpwardSharp } from "@mui/icons-material";
 import { IconButton } from "@mui/material";
+import { UserContext } from "../../contexts/UserContext.jsx";
 
-const CommentVotes = ({ comment_id, votes }) => {
+const CommentVotes = ({ comment_id, votes, author }) => {
+  const { loggedInUser } = useContext(UserContext);
   const [commentVotes, setCommentVotes] = useState(votes);
   const [voteCheck, setVoteCheck] = useState(0);
 
@@ -16,18 +18,33 @@ const CommentVotes = ({ comment_id, votes }) => {
   return (
     <div className="comment-card-footer">
       <div className="comment-card-vote-count">
-        <IconButton onClick={() => voteAction(1)} disabled={voteCheck === 1}>
+        <IconButton
+          onClick={() => voteAction(1)}
+          disabled={voteCheck === 1 || loggedInUser.username === author}
+        >
           <ArrowUpwardSharp
             className={`up-arrow ${
-              voteCheck === 1 ? `orange-highlight` : null
+              voteCheck === 1
+                ? `orange-highlight`
+                : loggedInUser.username === author
+                ? `greyed-out`
+                : null
             }`}
+            disabled={loggedInUser.username === author}
           />
         </IconButton>
         {commentVotes}
-        <IconButton onClick={() => voteAction(-1)} disabled={voteCheck === -1}>
+        <IconButton
+          onClick={() => voteAction(-1)}
+          disabled={voteCheck === -1 || loggedInUser.username === author}
+        >
           <ArrowDownwardSharp
             className={`down-arrow ${
-              voteCheck === -1 ? `orange-highlight` : null
+              voteCheck === -1
+                ? `orange-highlight`
+                : loggedInUser.username === author
+                ? `greyed-out`
+                : null
             }`}
           />
         </IconButton>

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -29,3 +29,11 @@ export const fetchArticleComments = (article_id) => {
     .get(`/articles/${article_id}/comments`)
     .then(({ data: { comments } }) => comments);
 };
+
+export const patchArticleVotes = (article_id, votes) => {
+  return newsApi.patch(`/articles/${article_id}`, { inc_votes: votes });
+};
+
+export const patchCommentVotes = (comment_id, votes) => {
+  return newsApi.patch(`/comments/${comment_id}`, { inc_votes: votes });
+};


### PR DESCRIPTION
This PR:

- Adds the ability to click the up and down arrows next to the voting scores on articles and comments and doing so will either increase or decrease the total.
- On click there will be an api call to patch the new vote number onto the specific record.
- The click optimistically renders to ensure the vote displayers an increase and decrease when clicked.
- The click only allows the user to vote up and down by an increment of one either way.
- Users can remove cast votes.
- Users are prevented from up or down voting their own articles and comments and styling reflects this.